### PR TITLE
Make existing_file_path always pathlib.Path

### DIFF
--- a/omg/datamodule/structure_dataset.py
+++ b/omg/datamodule/structure_dataset.py
@@ -112,7 +112,7 @@ class StructureDataset(Dataset):
         path = Path(file_path)
 
         if path.exists():
-            existing_file_path = file_path
+            existing_file_path = path
         else:
             # Try to use the data from the omg package.
             # noinspection PyTypeChecker


### PR DESCRIPTION
Ensure existing_file_path is always a pathlib.Path object.
Previously `if path.exists()` set existing_file_path to string, while `else` set to pathlib.Path